### PR TITLE
list templates from s3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ Actions:
 ## Configuration
 
 CFN_TEMPLATE_URL="s3://bucket/path"
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION="us-east-1"

--- a/lib/cog_cmd/cfn/helpers.rb
+++ b/lib/cog_cmd/cfn/helpers.rb
@@ -1,0 +1,16 @@
+require 'cog/command'
+
+module CogCmd::Cfn::Helpers
+  def strip_prefix(str)
+    str.sub(template_url[:prefix], "")
+  end
+
+  def strip_json(str)
+    str.sub(/\.json$/, "")
+  end
+
+  def template_url
+    url = env_var("CFN_TEMPLATE_URL", required: true)
+    url.match(/((?<scheme>[^:]+):\/\/)?(?<bucket>[^\/]+)\/(?<prefix>.*)/)
+  end
+end


### PR DESCRIPTION
Adds `cfn:template list` command. It's a pretty simple command. It just looks in an s3 bucket for json files and returns a list of them along with there last modified date. There is no sorting and whatnot.

Configured with:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_REGION
- CFN_TEMPLATE_URL

Right now there are no options or args to pass. Maybe we add options to override the region or the template_url? `--region` `--template-url`
