### PR TITLE
Imbriaco/subcommand refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cog-rb', '~> 0.2.0'
+gem 'cog-rb', '~> 0.3.0'
 gem 'aws-sdk', '~> 2.5'
 
 group "development", "test" do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.5.5)
       aws-sdk-core (= 2.5.5)
-    cog-rb (0.2.0)
+    cog-rb (0.3.0)
       rake (~> 11.2)
     diff-lcs (1.2.5)
     jmespath (1.3.1)
@@ -31,7 +31,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk (~> 2.5)
-  cog-rb (~> 0.2.0)
+  cog-rb (~> 0.3.0)
   rspec
 
 BUNDLED WITH

--- a/lib/cog_cmd/cfn/changeset/apply.rb
+++ b/lib/cog_cmd/cfn/changeset/apply.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Changeset::Apply < Cog::SubCommand
+class CogCmd::Cfn::Changeset::Apply < Cog::Command
   USAGE = <<~END
   Usage: cfn:changeset apply <change set id> | <change set name> <stack name>
 

--- a/lib/cog_cmd/cfn/changeset/create.rb
+++ b/lib/cog_cmd/cfn/changeset/create.rb
@@ -1,7 +1,7 @@
 require_relative '../exceptions'
 require_relative '../helpers'
 
-class CogCmd::Cfn::Changeset::Create < Cog::SubCommand
+class CogCmd::Cfn::Changeset::Create < Cog::Command
 
   include CogCmd::Cfn::Helpers
 

--- a/lib/cog_cmd/cfn/changeset/delete.rb
+++ b/lib/cog_cmd/cfn/changeset/delete.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Changeset::Delete < Cog::SubCommand
+class CogCmd::Cfn::Changeset::Delete < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:changeset delete <change set id> | <change set name> <stack name>

--- a/lib/cog_cmd/cfn/changeset/list.rb
+++ b/lib/cog_cmd/cfn/changeset/list.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Changeset::List < Cog::SubCommand
+class CogCmd::Cfn::Changeset::List < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:changeset list <stack name>

--- a/lib/cog_cmd/cfn/changeset/show.rb
+++ b/lib/cog_cmd/cfn/changeset/show.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Changeset::Show < Cog::SubCommand
+class CogCmd::Cfn::Changeset::Show < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:changeset show <change set id> | <change set name> <stack name>

--- a/lib/cog_cmd/cfn/stack/create.rb
+++ b/lib/cog_cmd/cfn/stack/create.rb
@@ -1,7 +1,7 @@
 require_relative '../exceptions'
 require_relative '../helpers'
 
-class CogCmd::Cfn::Stack::Create < Cog::SubCommand
+class CogCmd::Cfn::Stack::Create < Cog::Command
 
   include CogCmd::Cfn::Helpers
 

--- a/lib/cog_cmd/cfn/stack/delete.rb
+++ b/lib/cog_cmd/cfn/stack/delete.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Stack::Delete < Cog::SubCommand
+class CogCmd::Cfn::Stack::Delete < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:stack delete <stack name>

--- a/lib/cog_cmd/cfn/stack/events.rb
+++ b/lib/cog_cmd/cfn/stack/events.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Stack::Events < Cog::SubCommand
+class CogCmd::Cfn::Stack::Events < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:stack events <stack name>

--- a/lib/cog_cmd/cfn/stack/list.rb
+++ b/lib/cog_cmd/cfn/stack/list.rb
@@ -1,6 +1,6 @@
 require_relative '../helpers'
 
-class CogCmd::Cfn::Stack::List < Cog::SubCommand
+class CogCmd::Cfn::Stack::List < Cog::Command
 
   include CogCmd::Cfn::Helpers
 

--- a/lib/cog_cmd/cfn/stack/resources.rb
+++ b/lib/cog_cmd/cfn/stack/resources.rb
@@ -1,6 +1,6 @@
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Stack::Resources < Cog::SubCommand
+class CogCmd::Cfn::Stack::Resources < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:stack resources <stack name>

--- a/lib/cog_cmd/cfn/stack/show.rb
+++ b/lib/cog_cmd/cfn/stack/show.rb
@@ -1,7 +1,7 @@
 require_relative '../exceptions'
 require_relative '../helpers'
 
-class CogCmd::Cfn::Stack::Show < Cog::SubCommand
+class CogCmd::Cfn::Stack::Show < Cog::Command
 
   include CogCmd::Cfn::Helpers
 

--- a/lib/cog_cmd/cfn/stack/template.rb
+++ b/lib/cog_cmd/cfn/stack/template.rb
@@ -1,7 +1,7 @@
 require 'json'
 require_relative '../exceptions'
 
-class CogCmd::Cfn::Stack::Template < Cog::SubCommand
+class CogCmd::Cfn::Stack::Template < Cog::Command
 
   USAGE = <<~END
   Usage: cfn:stack template <stack name>

--- a/lib/cog_cmd/cfn/template/list.rb
+++ b/lib/cog_cmd/cfn/template/list.rb
@@ -1,6 +1,6 @@
 require_relative '../helpers'
 
-class CogCmd::Cfn::Template::List < Cog::SubCommand
+class CogCmd::Cfn::Template::List < Cog::Command
 
   include CogCmd::Cfn::Helpers
 

--- a/lib/cog_cmd/cfn/template/show.rb
+++ b/lib/cog_cmd/cfn/template/show.rb
@@ -1,7 +1,7 @@
 require_relative '../exceptions'
 require_relative '../helpers'
 
-class CogCmd::Cfn::Template::Show < Cog::SubCommand
+class CogCmd::Cfn::Template::Show < Cog::Command
 
   include CogCmd::Cfn::Helpers
 


### PR DESCRIPTION
Updates to cog-rb v0.3.0 and updates subcommand implementations to use Cog::Command as the parent class instead of Cog::SubCommand.