### PR TITLE
add an optional prefix to filter listed templates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ commands:
   template-list:
     executable: "/home/bundle/cog-command"
     description: List available CloudFormation templates
+    arguments: "[template_prefix]"
     rules:
     - must have cfn:template
   template-show:

--- a/lib/cog_cmd/cfn/template/list.rb
+++ b/lib/cog_cmd/cfn/template/list.rb
@@ -5,6 +5,12 @@ module CogCmd::Cfn::Template
 
     include  CogCmd::Cfn::Helpers
 
+    attr_reader :template_prefix
+
+    def initialize
+      @template_prefix = request.args[0]
+    end
+
     def run_command
       response.template = 'template_list'
       response.content = list_templates.reduce([]) do |acc, obj|
@@ -25,7 +31,7 @@ module CogCmd::Cfn::Template
 
       params = {
         bucket: template_root[:bucket],
-        prefix: template_root[:prefix]
+        prefix: prefix
       }
 
       client.list_objects_v2(params).contents
@@ -38,6 +44,12 @@ module CogCmd::Cfn::Template
     def process_obj(obj)
       { name: strip_json(strip_prefix(obj.key)),
         last_modified: obj.last_modified }
+    end
+
+    def prefix
+      return template_root[:prefix] unless template_prefix
+
+      "#{template_root[:prefix]}#{template_prefix}"
     end
 
   end


### PR DESCRIPTION
You can pass an optional prefix to the `template-list` command, to filter template.

resolves #21 