### PR TITLE
do not show parameters and outputs by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,10 @@
 cog_bundle_version: 4
 name: cfn
 description: AWS CloudFormation
-version: 0.5.8
+version: 0.5.9
 docker:
   image: cogcmd/aws-cfn
-  tag: 0.5.8
+  tag: 0.5.9
 author: Operable <support@operable.io>
 homepage: https://github.com/cogcmd/aws-cfn
 long_description: |
@@ -186,6 +186,11 @@ commands:
         required: false
         short_flag: c
         description: 'Can be one of: iam or named_iam.'
+      verbose:
+        type: bool
+        required: false
+        short_flag: v
+        description: Display verbose stack details, including parameters and outputs.
     rules:
     - must have cfn:stack
   stack-delete:
@@ -249,6 +254,12 @@ commands:
     executable: "/home/bundle/cog-command"
     description: Shows details for a stack.
     arguments: "<stack-name>"
+    options:
+      verbose:
+        type: bool
+        required: false
+        short_flag: v
+        description: Display verbose stack details, including parameters and outputs.
     rules:
     - must have cfn:stack
   changeset-create:
@@ -573,20 +584,6 @@ templates:
       **Stack Status:** ~$results[0].stack_status~
       ~if cond=$results[0].last_updated_time not_empty?~**Last Update:** ~$results[0].last_updated_time~~end~
 
-      **Parameters:**
-      ~if cond=$results[0].parameters empty?~None~end~
-
-      ~each var=$results[0].parameters~
-      * ~$item.parameter_key~=~$item.parameter_value~
-      ~end~
-
-      **Outputs:**
-      ~if cond=$results[0].outputs empty?~None~end~
-
-      ~each var=$results[0].outputs as=item~
-      * ~$item.output_key~=~$item.output_value~
-      ~end~
-
       **Tags:**
       ~if cond=$results[0].tags empty?~None~end~
 
@@ -807,3 +804,30 @@ templates:
       **Status:** ~$results[0].stack_status~
   changeset_missing_stack_name:
     body: 'Error: Unable to list stacks.'
+  stack_show_verbose:
+    body: |
+      **Stack:** ~$results[0].stack_name~
+      **Description:** ~$results[0].description~
+      **Stack Status:** ~$results[0].stack_status~
+      ~if cond=$results[0].last_updated_time not_empty?~**Last Update:** ~$results[0].last_updated_time~~end~
+
+      **Parameters:**
+      ~if cond=$results[0].parameters empty?~None~end~
+
+      ~each var=$results[0].parameters~
+      * ~$item.parameter_key~=~$item.parameter_value~
+      ~end~
+
+      **Outputs:**
+      ~if cond=$results[0].outputs empty?~None~end~
+
+      ~each var=$results[0].outputs as=item~
+      * ~$item.output_key~=~$item.output_value~
+      ~end~
+
+      **Tags:**
+      ~if cond=$results[0].tags empty?~None~end~
+
+      ~each var=$results[0].tags as=item~
+      * ~$item.key~=~$item.value~
+      ~end~

--- a/lib/cog_cmd/cfn/stack/create.rb
+++ b/lib/cog_cmd/cfn/stack/create.rb
@@ -13,6 +13,7 @@ module CogCmd::Cfn::Stack
     attr_reader :stack_params, :tags, :policy, :notify, :on_failure, :timeout, :capabilities
 
     def initialize
+      @cog_template = request.options['verbose'] ? 'stack_show_verbose' : 'stack_show'
       @definition = request.options['definition']
 
       if @definition
@@ -47,7 +48,7 @@ module CogCmd::Cfn::Stack
       raise(Cog::Abort, "You must specify a stack name AND a template name.") unless stack_name
       raise(Cog::Abort, "You must specify a stack name AND a template name.") unless template_url
 
-      response.template = 'stack_show'
+      response.template = @cog_template
       response.content = create_stack
     end
 

--- a/lib/cog_cmd/cfn/stack/show.rb
+++ b/lib/cog_cmd/cfn/stack/show.rb
@@ -7,16 +7,17 @@ module CogCmd::Cfn::Stack
 
     include CogCmd::Cfn::Helpers
 
-    attr_reader :stack_name
+    attr_reader :stack_name, :cog_template
 
     def initialize
       @stack_name = request.args[0]
+      @cog_template = request.options['verbose'] ? 'stack_show_verbose' : 'stack_show'
     end
 
     def run_command
       raise(Cog::Abort, "You must specify a stack name.") unless stack_name
 
-      response.template = 'stack_show'
+      response.template = @cog_template
       response.content = cfn_client.describe_stack(@stack_name)
     end
   end

--- a/templates/stack_show.greenbar
+++ b/templates/stack_show.greenbar
@@ -3,20 +3,6 @@
 **Stack Status:** ~$results[0].stack_status~
 ~if cond=$results[0].last_updated_time not_empty?~**Last Update:** ~$results[0].last_updated_time~~end~
 
-**Parameters:**
-~if cond=$results[0].parameters empty?~None~end~
-
-~each var=$results[0].parameters~
-* ~$item.parameter_key~=~$item.parameter_value~
-~end~
-
-**Outputs:**
-~if cond=$results[0].outputs empty?~None~end~
-
-~each var=$results[0].outputs as=item~
-* ~$item.output_key~=~$item.output_value~
-~end~
-
 **Tags:**
 ~if cond=$results[0].tags empty?~None~end~
 


### PR DESCRIPTION
By default, do not include parameters and outputs in the chat output. Adds a `-v` / `--verbose` flag to show them if desired.

Fixes #27
Fixes #28 
