### PR TITLE
grant bucket owner full access to all objects that are put in s3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,10 @@
 cog_bundle_version: 4
 name: cfn
 description: AWS CloudFormation
-version: 0.5.11
+version: 0.5.12
 docker:
   image: cogcmd/aws-cfn
-  tag: 0.5.11
+  tag: 0.5.12
 author: Operable <support@operable.io>
 homepage: https://github.com/cogcmd/aws-cfn
 long_description: |

--- a/lib/cfn/s3_client.rb
+++ b/lib/cfn/s3_client.rb
@@ -48,8 +48,14 @@ module Cfn
 
     def create_file(key, body, params = {})
       key = "#{prefix}/#{key}" unless prefix.nil?
-      params.merge!(bucket: bucket, key: key, body: body)
-      @client.put_object(params)
+      params.merge!(bucket: bucket, key: key)
+
+      put_params = params.merge(body: body)
+      @client.put_object(put_params)
+
+      acl_params = params.merge(acl: "bucket-owner-full-control")
+      @client.put_object_acl(acl_params)
+
       params
     end
 


### PR DESCRIPTION
If multiple accounts are used via STS we need to make sure the bucket owner can access all objects that are uploaded. This could fall down some if more than 2 accounts are at play, but is probably good enough for now.